### PR TITLE
Multiple parsers added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ADD . /api
 WORKDIR /api
-RUN apt-get update && apt-get install -y python3.5-dev python3.5 python3-setuptools libssl-dev libffi-dev wget build-essential xz-utils bzip2 tar unzip git
+RUN apt-get update && apt-get install -y python3.5-dev python3.5 python3-setuptools libssl-dev libffi-dev wget build-essential xz-utils bzip2 tar unzip git python3-pip
 RUN \
   wget https://github.com/ispras/lingvodoc-ext-oslon/archive/master.zip -O /tmp/master.zip && \
   unzip /tmp/master.zip -d /tmp/ && \
@@ -16,7 +16,7 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /etc/
 	apt-get update && \
 	apt-get install -y postgresql-server-dev-10 postgresql-client-10
 RUN \
-  easy_install3 pip==9.0.1 && \
+  pip3 install pip==9.0.1 && \
   pip3 install --upgrade setuptools==40.8.0 && \
   pip3 install -r server-requirements.txt && \
   pip3 install alembic gunicorn==19.7.1

--- a/alembic/versions/9d40fd0124a6_parsers.py
+++ b/alembic/versions/9d40fd0124a6_parsers.py
@@ -42,7 +42,7 @@ def upgrade():
         content text
         );
     
-	INSERT INTO public.parser (additional_metadata, created_at, object_id, client_id, name, parameters, method) VALUES (null, '2020-10-28 20:19:36.000000', 1, 1, 'Парсер удмуртского языка Т.Архангельского', '[]', 'timarkh_udm');
+	    INSERT INTO public.parser (additional_metadata, created_at, object_id, client_id, name, parameters, method) VALUES (null, '2020-10-28 20:19:36.000000', 1, 1, 'Парсер удмуртского языка Т.Архангельского', '[]', 'timarkh_udm');
         INSERT INTO public.parser (additional_metadata, created_at, object_id, client_id, name, parameters, method) VALUES (null, '2020-10-28 20:21:55.000000', 2, 1, 'Парсер эрзянского языка Т.Архангельского', '[]', 'timarkh_erzya');
         INSERT INTO public.parser (additional_metadata, created_at, object_id, client_id, name, parameters, method) VALUES (null, '2020-10-28 20:21:58.000000', 3, 1, 'Парсер марийского лугового языка Т.Архангельского', '[]', 'timarkh_meadow_mari');
         INSERT INTO public.parser (additional_metadata, created_at, object_id, client_id, name, parameters, method) VALUES (null, '2020-10-28 20:22:00.000000', 4, 1, 'Парсер мокшанского языка Т.Архангельского', '[]', 'timarkh_moksha');

--- a/alembic/versions/d7a6389ac968_komi_zyryan_parser.py
+++ b/alembic/versions/d7a6389ac968_komi_zyryan_parser.py
@@ -1,0 +1,27 @@
+"""komi_zyryan_parser
+
+Revision ID: d7a6389ac968
+Revises: bea877f1af75
+Create Date: 2020-11-18 20:06:07.849196
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd7a6389ac968'
+down_revision = 'bea877f1af75'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+
+def upgrade():
+    op.execute('''
+    INSERT INTO public.parser(additional_metadata, created_at, object_id, client_id, name, parameters, method)
+    VALUES(null, '2020-10-28 20:22:00.000000', 5, 1, 'Парсер коми-зырянского языка Т.Архангельского', '[]',
+           'timarkh_komi_zyryan');
+    ''')
+
+def downgrade():
+    op.execute('''
+    DELETE FROM parser WHERE method = 'timarkh_moksha';
+    ''')

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,6 +51,6 @@ services:
 
     env_file:
       - ./locale_env.sh
-    command: bash -c "python3 setup.py clean && python3 setup.py install --react-interface=/dist && /api/wait-for-postgres.sh pg gunicorn --paster /api/docker/docker.ini"
+    command: bash -c "python3 setup.py clean && python3 setup.py install --react-interface=/dist && /api/wait-for-postgres.sh pg gunicorn --preload --paster /api/docker/docker.ini"
     ports:
       - "16543:6543"

--- a/lingvodoc/schema/gql_entity.py
+++ b/lingvodoc/schema/gql_entity.py
@@ -130,9 +130,10 @@ class Entity(LingvodocObjectType):
 
     @fetch_object('is_subject_for_parsing')
     def resolve_is_subject_for_parsing(self, info):
+        supported_extensions = (".odt", ".doc", ".docx")
         if self.dbObject.content:
             extension = self.dbObject.content[self.dbObject.content.rfind('.'):]
-            if extension == ".odt":
+            if extension in supported_extensions:
                 return True
         return False
 

--- a/lingvodoc/schema/gql_parserresult.py
+++ b/lingvodoc/schema/gql_parserresult.py
@@ -120,10 +120,7 @@ class ExecuteParser(graphene.Mutation):
             raise ResponseError(message="Dedoc server url was not provided in configuration")
 
         async = args.get("async")
-        if async == None:
-            async = True
-
-        if async:
+        if async == None or async == True:
             task = TaskStatus(user_id, "Parsing entity", "", 2)
             cur_args["task_key"] = task.key
             cur_args["cache_kwargs"] = request.registry.settings["cache_kwargs"]

--- a/lingvodoc/utils/creation.py
+++ b/lingvodoc/utils/creation.py
@@ -473,8 +473,8 @@ def create_parser_result(id, parser_id, entity_id, dedoc_url, arguments=None, sa
     tmp_file_id, tmp_filename = tempfile.mkstemp()
     tmp_file = open(tmp_filename, 'wb')
     tmp_file.write(response.read())
-    os.rename(tmp_filename, tmp_filename + ".odt")
-    tmp_filename = tmp_filename + ".odt"
+    os.rename(tmp_filename, tmp_filename + extension)
+    tmp_filename = tmp_filename + extension
 
     result = parse_method(tmp_filename, dedoc_url, **arguments)
 

--- a/lingvodoc/utils/doc_parser.py
+++ b/lingvodoc/utils/doc_parser.py
@@ -1,14 +1,16 @@
 import json
 import re
 
-from udmparser.analyzer.analyze import analyze
+from udmparser.analyzer.analyze import analyze as analyze_udm
+from erzyanparser.analyzer.analyze import analyze as analyze_erzya
+from mokshanparser.analyzer.analyze import analyze as analyze_moksha
+from komizyryanparser.analyzer.analyze import analyze as analyze_komi_zyryan
+from meadowmariparser.analyzer.analyze import analyze as analyze_meadow_mari
 from nltk.tokenize import RegexpTokenizer
 import csv
 import os
 import tempfile
 import bs4
-from odf import text, teletype
-from odf.opendocument import load
 import requests
 
 # Extracts html string with headers using dedoc module
@@ -39,17 +41,16 @@ def analyze(freqListFile, paradigmFile, lexFile, lexRulesFile,
 # Parses an odt file with udmurtian text, returns an html string with parsed words wrapped into tags
 
 
-def timarkh_udm(content_file, dedoc_url):
-
-    # Load pure text string from the file
-    doc = load(content_file)
-    content_for_parsing = teletype.extractText(doc.text)
+def timarkh_uniparser(content_file, dedoc_url, lang):
 
     # Save dedoc module output for further result composing
     # Exclude sub tag with content as have no need in it
     dedoc_output = dedoc_extract(content_file, dedoc_url)
+    dedoc_output = re.sub(r"(<sub>.*?</sub>)", "", dedoc_output)
 
+    # Build the content for parsing by formatting the dedoc's output
     # Build a csv file with frequences of each word in the input document to pass it to the parsing function
+    content_for_parsing = re.sub(r"(<.*?>)", "", dedoc_output)
     content_for_parsing = content_for_parsing.replace('\n', '')
     tokenizer = RegexpTokenizer(r'\w+')
     freq_dict = dict()
@@ -70,7 +71,17 @@ def timarkh_udm(content_file, dedoc_url):
     unparsed_file_id, unparsed_filename = tempfile.mkstemp()
     open(parsed_filename, 'w').close()
     open(unparsed_filename, 'w').close()
-    analyze(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
+
+    if lang == 'udm':
+        analyze_udm(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
+    if lang == 'erzya':
+        analyze_erzya(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
+    if lang == 'moksha':
+        analyze_moksha(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
+    if lang == 'komi_zyryan':
+        analyze_komi_zyryan(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
+    if lang == 'meadow_mari':
+        analyze_meadow_mari(freqListFile=csv_filename, parsedFile=parsed_filename, unparsedFile=unparsed_filename)
 
     def insert_parser_results(parser_output, dedoc_output):
 
@@ -155,6 +166,23 @@ def timarkh_udm(content_file, dedoc_url):
     os.remove(unparsed_filename)
 
     return result
+
+
+def timarkh_udm(content_file, dedoc_url):
+    return timarkh_uniparser(content_file, dedoc_url, 'udm')
+
+def timarkh_erzya(content_file, dedoc_url):
+    return timarkh_uniparser(content_file, dedoc_url, 'erzya')
+
+def timarkh_moksha(content_file, dedoc_url):
+    return timarkh_uniparser(content_file, dedoc_url, 'moksha')
+
+def timarkh_komi_zyryan(content_file, dedoc_url):
+    return timarkh_uniparser(content_file, dedoc_url, 'komi_zyryan')
+
+def timarkh_meadow_mari(content_file, dedoc_url):
+    return timarkh_uniparser(content_file, dedoc_url, 'meadow_mari')
+
 
 
 

--- a/server-requirements.txt
+++ b/server-requirements.txt
@@ -11,6 +11,10 @@ dataproperty==0.42.1
 dogpile.cache==0.6.2
 git+https://github.com/myrix/poio-api.git
 git+https://github.com/ankan2013/udmparser.git
+git+https://github.com/ankan2013/erzyanparser.git
+git+https://github.com/ankan2013/mokshanparser.git
+git+https://github.com/ankan2013/komizyryanparser.git
+git+https://github.com/ankan2013/meadowmariparser.git
 GitPython==3.1.0
 graf-python==0.3.1
 graphene==2.0.1


### PR DESCRIPTION
Pip installation was changed as easy_install3 had problems with ssl certificates. Also the flag --preload was added to the command in docker-compose.yml to get readable error messages (not only something like "ld exited with code 3") from lingvodoc container, which may be helpful in further development.