### PR TITLE
Glottochronology -- replace 'ё' to 'е'

### DIFF
--- a/lingvodoc/schema/gql_cognate.py
+++ b/lingvodoc/schema/gql_cognate.py
@@ -4560,7 +4560,7 @@ class SwadeshAnalysis(graphene.Mutation):
                 if "убрать из стословника" in lex:
                     return set()
 
-                return set(form.strip()
+                return set(form.replace('ё', 'е').strip()
                            for form in lex.replace('(', ',').split(',')
                            if form.strip() and ')' not in form)  # exclude notes
 


### PR DESCRIPTION
Replaced 'ё' to 'е' for correct compare